### PR TITLE
Harden quiz flow and polish UX

### DIFF
--- a/docs/cambios-fix-quiz-hardening.md
+++ b/docs/cambios-fix-quiz-hardening.md
@@ -1,0 +1,59 @@
+# Cambios realizados en `codex/fix-quiz-hardening`
+
+Fecha: 1 de mayo de 2026
+
+## Objetivo
+
+Reforzar la app sin cambiar su enfoque de producto: mismo flujo, menos errores, mejor accesibilidad y un consentimiento de cookies más correcto.
+
+## Cambios funcionales
+
+- Se evita responder varias veces la misma pregunta.
+- Se bloquean las opciones justo después de la primera respuesta.
+- Se mantiene el botón `Continuar` con una breve pausa para que el usuario vea el resultado.
+- Se añade un contador visible de progreso: `Pregunta X de 10`.
+
+## Manejo de errores
+
+- Se añade control de errores al cargar `menu_temas.json`.
+- Se añade control de errores al cargar cada cuestionario JSON.
+- Se muestra un mensaje claro al usuario si falla la carga.
+- Se añade botón de reintento para no dejar la app en un estado silencioso.
+
+## Accesibilidad y UX
+
+- Las respuestas dejan de ser `li` clicables y pasan a renderizarse como botones reales.
+- Se mejora la navegación por teclado.
+- El feedback ya no depende solo del color: ahora aparece texto visual de `Correcta` o `Incorrecta`.
+- Se añade una región `aria-live` para anunciar el resultado de la respuesta.
+
+## Cookies y analítica
+
+- Google Analytics ya no se carga al entrar en la página.
+- Analytics solo se inicializa si el usuario acepta cookies analíticas.
+- Se sustituye el banner anterior por uno con dos opciones: aceptar o rechazar.
+- La decisión se guarda en `localStorage`.
+
+## Política de cookies
+
+- Se fija una fecha de actualización real en lugar de mostrar siempre la fecha actual del navegador.
+- Se aclara que las cookies analíticas solo se activan con consentimiento.
+
+## Archivos modificados
+
+- `index.html`
+- `styles.css`
+- `docs/cookies.html`
+
+## Nota técnica
+
+La app sigue siendo una web estática y sencilla de desplegar en GitHub Pages. Los cambios están pensados para mejorar robustez y cumplimiento básico sin introducir build tools ni dependencias nuevas.
+
+## Segunda pasada: diseño responsive y copy
+
+- Se mejora la cabecera con una propuesta de valor más clara.
+- El botón principal pasa de `Play` a `Empezar`.
+- La pantalla inicial explica mejor qué hace la app y qué esperar de cada partida.
+- La pantalla de temas incluye una introducción más útil.
+- La pantalla de resultados añade mensaje de desempeño, tarjetas de métricas y acción directa para repetir el mismo cuestionario.
+- Se refina el estilo visual con contenedores tipo panel, mejor espaciado, jerarquía tipográfica y una adaptación móvil más cuidada.

--- a/docs/cookies.html
+++ b/docs/cookies.html
@@ -12,7 +12,7 @@
 		Proyecto PAI - Liceo Europeo - 2025
 	</footer>
     <h2>Política de Cookies</h2>
-    <p><strong>Última actualización:</strong> <span id="fecha-actualizacion"></span></p>
+    <p><strong>Última actualización:</strong> 1 de mayo de 2026</p>
 
     <h2>1. ¿Qué son las cookies?</h2>
     <p>Las cookies son pequeños archivos de texto que se almacenan en tu dispositivo (ordenador, móvil, tableta, etc.) cuando visitas un sitio web. Se utilizan para mejorar tu experiencia de navegación, recordar tus preferencias y analizar el uso del sitio web.</p>
@@ -32,7 +32,7 @@
     <p>Algunas páginas pueden incluir contenido de terceros, como vídeos de YouTube o botones de redes sociales. Estos servicios pueden usar sus propias cookies para rastrear tu actividad en nuestro sitio.</p>
 
     <h2>3. ¿Cómo puedes gestionar las cookies?</h2>
-    <p>Puedes aceptar o rechazar el uso de cookies desde el <strong>banner de cookies</strong> que aparece al visitar nuestra web. También puedes configurar tu navegador para bloquearlas o eliminarlas en cualquier momento.</p>
+    <p>Puedes aceptar o rechazar el uso de cookies desde el <strong>banner de cookies</strong> que aparece al visitar nuestra web. Solo activamos las cookies analíticas si das tu consentimiento. También puedes configurar tu navegador para bloquearlas o eliminarlas en cualquier momento.</p>
 
     <p><strong>Cómo gestionar cookies en navegadores populares:</strong></p>
     <ul>
@@ -46,11 +46,5 @@
     <p>Podemos actualizar esta política en cualquier momento. Notificaremos cualquier cambio significativo publicando la nueva versión en esta página.</p>
 
     <p>Si tienes dudas, contáctanos en <a href="mailto:dpo@montus.es">dpo@montus.es</a>.</p>
-
-    <script>
-        // Insertar la fecha actual automáticamente
-        document.getElementById("fecha-actualizacion").textContent = new Date().toLocaleDateString("es-ES");
-    </script>
-
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,75 +6,126 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>APPistóteles</title> <!-- Confirmar el nombre de la app para la barra de estado del navegador -->
 	<link rel="stylesheet" href="styles.css">
-	<!-- Google Analytics tag (gtag.js) -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=G-THDDLME63J"></script>
-	<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag() { dataLayer.push(arguments); }
-		gtag('js', new Date());
-
-		gtag('config', 'G-THDDLME63J');
-	</script>
-	<!-- fin - Google Analytics tag (gtag.js) -->
-	<!-- Banner de cookies -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css" />
-	<script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js"></script>
-	<script>
-		window.addEventListener("load", function () {
-			window.cookieconsent.initialise({
-				palette: {
-					popup: { background: "#000" },
-					button: { background: "#f1d600" }
-				},
-				theme: "classic",
-				position: "bottom",
-				content: {
-					message: "Este sitio web usa cookies para mejorar la experiencia del usuario.",
-					dismiss: "Aceptar",
-					link: "Leer más",
-					href: "https://appistoteles.com/docs/cookies.html"
-				}
-			});
-		});
-	</script>
-	<!-- fin - Banner de cookies -->
 </head>
 
 <body>
-	<h1>APPistóteles</h1>
-	<div id="pantalla-inicio" class="pantalla activa">
-		<p>
-			Bienvenido a APPistóteles, tu app favorita para aprender historia de una manera fácil y entretenida.
-			<br><br>
-			Escoge un tema de la lista que quieras repasar y responde a las 10 preguntas del siguiente cuestionario.
-		</p>
-		<button id="btn-play">Play</button>
+	<header class="site-header">
+		<p class="eyebrow">Historia en formato quiz</p>
+		<h1>APPistóteles</h1>
+		<p class="site-subtitle">Una forma simple y visual de repasar historia, tema a tema.</p>
+	</header>
+
+	<main class="app-shell">
+	<div id="pantalla-inicio" class="pantalla activa panel">
+		<div class="hero-copy">
+			<h2>Aprende historia sin sentir que estudias</h2>
+			<p>
+				Elige un tema, responde 10 preguntas aleatorias y recibe una explicación breve en cada respuesta.
+				Ideal para repasar, practicar y detectar lo que todavía no tienes del todo claro.
+			</p>
+		</div>
+		<div class="hero-highlights" aria-label="Características principales">
+			<p class="highlight-pill">17 temas históricos</p>
+			<p class="highlight-pill">10 preguntas por partida</p>
+			<p class="highlight-pill">Explicaciones inmediatas</p>
+		</div>
+		<button id="btn-play">Empezar</button>
 	</div>
 
-	<div id="pantalla-menu" class="pantalla">
+	<div id="pantalla-menu" class="pantalla panel">
 		<h2>Selecciona un tema</h2>
+		<p class="section-intro">Escoge el bloque histórico que quieras repasar. Las preguntas se mezclan automáticamente en cada intento.</p>
 		<ul id="lista-temas"></ul>
 	</div>
 
-	<div id="pantalla-cuestionario" class="pantalla">
+	<div id="pantalla-cuestionario" class="pantalla panel">
 		<div id="pregunta-container"></div>
 		<ul id="opciones"></ul>
+		<p id="estado-respuesta" class="estado-respuesta" aria-live="polite"></p>
 		<div id="explicacion-container" class="oculto"></div>
-		<button id="btn-continuar" class="oculto">Continuar</button>
+		<button id="btn-continuar" class="oculto">Siguiente pregunta</button>
 	</div>
 
-	<div id="pantalla-resultados" class="pantalla">
+	<div id="pantalla-resultados" class="pantalla panel">
 		<h2>Resultados</h2>
-		<p>Aciertos: <span id="aciertos"></span></p>
-		<p>Fallos: <span id="fallos"></span></p>
-		<p>Puntos: <span id="puntos"></span></p>
-		<button id="btn-finalizar">Finalizar</button>
+		<p id="mensaje-resultado" class="section-intro"></p>
+		<div class="results-grid">
+			<div class="stat-card">
+				<p class="stat-label">Aciertos</p>
+				<p class="stat-value"><span id="aciertos"></span></p>
+			</div>
+			<div class="stat-card">
+				<p class="stat-label">Fallos</p>
+				<p class="stat-value"><span id="fallos"></span></p>
+			</div>
+			<div class="stat-card">
+				<p class="stat-label">Puntos</p>
+				<p class="stat-value"><span id="puntos"></span></p>
+			</div>
+		</div>
+		<div class="results-actions">
+			<button id="btn-repetir">Jugar otra vez</button>
+			<button id="btn-finalizar" class="secondary-button">Volver a temas</button>
+		</div>
 	</div>
+
+	<div id="mensaje-error" class="mensaje-error oculto" role="alert">
+		<p id="texto-error"></p>
+		<button id="btn-reintentar" class="oculto">Reintentar</button>
+	</div>
+
+	<div id="cookie-banner" class="cookie-banner oculto" role="dialog" aria-live="polite" aria-label="Preferencias de cookies">
+		<p>
+			Usamos cookies analíticas solo si las aceptas. Puedes cambiar tu decisión borrando las cookies del navegador.
+			<a href="docs/cookies.html">Leer política de cookies</a>
+		</p>
+		<div class="cookie-actions">
+			<button id="btn-aceptar-cookies" type="button">Aceptar</button>
+			<button id="btn-rechazar-cookies" type="button" class="secondary-button">Rechazar</button>
+		</div>
+	</div>
+	</main>
+
+	<footer>
+		Proyecto PAI - Liceo Europeo - 2025
+	</footer>
 
 	<script>
+		const ANALYTICS_ID = "G-THDDLME63J";
+		const COOKIE_CONSENT_KEY = "appistoteles_cookie_consent";
+		let ultimoIntento = null;
+		let ultimoCuestionario = null;
+
 		document.getElementById("btn-play").addEventListener("click", function () {
 			cambiarPantalla("pantalla-menu");
 			cargarTemas();
+		});
+
+		document.getElementById("btn-repetir").addEventListener("click", function () {
+			if (ultimoCuestionario) {
+				iniciarCuestionario(ultimoCuestionario);
+			} else {
+				cambiarPantalla("pantalla-menu");
+			}
+		});
+
+		document.getElementById("btn-reintentar").addEventListener("click", function () {
+			if (ultimoIntento) {
+				ultimoIntento();
+			}
+		});
+
+		document.getElementById("btn-finalizar").addEventListener("click", function () {
+			cambiarPantalla("pantalla-menu");
+		});
+
+		document.getElementById("btn-aceptar-cookies").addEventListener("click", function () {
+			guardarConsentimientoCookies("accepted");
+			inicializarAnalytics();
+		});
+
+		document.getElementById("btn-rechazar-cookies").addEventListener("click", function () {
+			guardarConsentimientoCookies("rejected");
 		});
 
 		function cambiarPantalla(idPantalla) {
@@ -82,31 +133,57 @@
 			document.getElementById(idPantalla).classList.add("activa");
 		}
 
-		function cargarTemas() {
-			fetch("menu_temas.json")
-				.then(response => response.json())
-				.then(data => {
-					let listaTemas = document.getElementById("lista-temas");
+		async function cargarTemas() {
+			const listaTemas = document.getElementById("lista-temas");
+			listaTemas.innerHTML = "";
+			ocultarError();
+			ultimoIntento = cargarTemas;
 
-					data.forEach(tema => {
-						let item = document.createElement("li");
-						item.textContent = tema.tema; // Acceder correctamente al nombre del tema
-						item.addEventListener("click", function () {
-							iniciarCuestionario(tema.cuestionario);
-						});
-						listaTemas.appendChild(item); // Agregar el elemento <li> a la lista
+			try {
+				const response = await fetch("menu_temas.json");
+				if (!response.ok) {
+					throw new Error("No se pudo cargar el menú de temas.");
+				}
+
+				const data = await response.json();
+				data.forEach(tema => {
+					const item = document.createElement("li");
+					const botonTema = document.createElement("button");
+					botonTema.type = "button";
+					botonTema.className = "option-button topic-button";
+					botonTema.textContent = tema.tema;
+					botonTema.addEventListener("click", function () {
+						iniciarCuestionario(tema.cuestionario);
 					});
-				})
+					item.appendChild(botonTema);
+					listaTemas.appendChild(item);
+				});
+			} catch (error) {
+				mostrarError("No hemos podido cargar los temas. Revisa la conexión o vuelve a intentarlo.", cargarTemas);
+			}
 		}
 
-		function iniciarCuestionario(archivoCuestionario) {
-			fetch(archivoCuestionario)
-				.then(response => response.json())
-				.then(data => {
-					let preguntas = data.preguntas.sort(() => 0.5 - Math.random()).slice(0, 10);
-					mostrarPregunta(preguntas, 0, 0, 0);
-				});
+		async function iniciarCuestionario(archivoCuestionario) {
 			cambiarPantalla("pantalla-cuestionario");
+			ocultarError();
+			ultimoIntento = () => iniciarCuestionario(archivoCuestionario);
+			ultimoCuestionario = archivoCuestionario;
+
+			try {
+				const response = await fetch(archivoCuestionario);
+				if (!response.ok) {
+					throw new Error("No se pudo cargar el cuestionario.");
+				}
+
+				const data = await response.json();
+				const preguntas = data.preguntas
+					.slice()
+					.sort(() => 0.5 - Math.random())
+					.slice(0, 10);
+				mostrarPregunta(preguntas, 0, 0, 0);
+			} catch (error) {
+				mostrarError("No hemos podido cargar este cuestionario. Puedes reintentarlo desde aquí.", () => iniciarCuestionario(archivoCuestionario));
+			}
 		}
 
 		function mostrarPregunta(preguntas, indice, aciertos, fallos) {
@@ -114,6 +191,7 @@
 				document.getElementById("aciertos").textContent = aciertos;
 				document.getElementById("fallos").textContent = fallos;
 				document.getElementById("puntos").textContent = aciertos * 10;
+				document.getElementById("mensaje-resultado").textContent = construirMensajeResultado(aciertos, preguntas.length);
 				cambiarPantalla("pantalla-resultados");
 				return;
 			}
@@ -121,61 +199,138 @@
 			let preguntaActual = preguntas[indice];
 			let preguntaContainer = document.getElementById("pregunta-container");
 			preguntaContainer.innerHTML = `
+			<p class="contador-pregunta">Pregunta ${indice + 1} de ${preguntas.length}</p>
 			<p>${preguntaActual.pregunta}</p>
 			${preguntaActual.imagen ? `<img src="${preguntaActual.imagen}" alt="Imagen de la pregunta" class="imagen-pregunta">` : ""}`;
-			//			document.getElementById("pregunta-container").textContent = preguntaActual.pregunta;
 			let opciones = document.getElementById("opciones");
 			opciones.innerHTML = "";
 			let explicacionContainer = document.getElementById("explicacion-container");
 			explicacionContainer.innerHTML = "";
 			explicacionContainer.classList.add("oculto");
+			explicacionContainer.classList.remove("explicacion-visible");
 			let btnContinuar = document.getElementById("btn-continuar");
 			btnContinuar.classList.add("oculto");
+			const estadoRespuesta = document.getElementById("estado-respuesta");
+			estadoRespuesta.textContent = "";
+			let respuestaBloqueada = false;
 
 			preguntaActual.opciones.forEach(opcion => {
 				let li = document.createElement("li");
-				li.textContent = opcion;
-				li.addEventListener("click", function () {
+				const botonOpcion = document.createElement("button");
+				botonOpcion.type = "button";
+				botonOpcion.className = "option-button";
+				botonOpcion.textContent = opcion;
+				botonOpcion.addEventListener("click", function () {
+					if (respuestaBloqueada) {
+						return;
+					}
+
+					respuestaBloqueada = true;
 					let correcta = opcion === preguntaActual.respuesta_correcta;
+					const botones = opciones.querySelectorAll(".option-button");
+					botones.forEach(item => {
+						item.disabled = true;
+					});
 
 					if (correcta) {
-						li.style.backgroundColor = "green";
-						li.style.color = "white";
-						li.style.fontWeight = "bold";
+						botonOpcion.classList.add("respuesta-correcta");
+						botonOpcion.setAttribute("aria-label", opcion + ". Respuesta correcta.");
+						estadoRespuesta.textContent = "Respuesta correcta.";
 						aciertos++;
 					} else {
-						li.style.backgroundColor = "red";
-						li.style.color = "white";
-						li.style.fontWeight = "bold";
+						botonOpcion.classList.add("respuesta-incorrecta");
+						botonOpcion.setAttribute("aria-label", opcion + ". Respuesta incorrecta.");
+						estadoRespuesta.textContent = "Respuesta incorrecta.";
 						fallos++;
-						// Resaltar la respuesta correcta en azul solo si la respuesta es incorrecta
-						opciones.querySelectorAll("li").forEach(item => {
+						botones.forEach(item => {
 							if (item.textContent === preguntaActual.respuesta_correcta) {
-								item.style.backgroundColor = "blue";
-								item.style.color = "white";
-								item.style.fontWeight = "bold";
+								item.classList.add("respuesta-correcta");
+								item.setAttribute("aria-label", item.textContent + ". Esta era la respuesta correcta.");
 							}
 						});
 					}
 
-					// Mostrar explicación siempre
 					explicacionContainer.textContent = preguntaActual.explicación;
 					explicacionContainer.classList.remove("oculto");
 					explicacionContainer.classList.add("explicacion-visible");
 
-					// Mostrar botón continuar después de 2 segundos
 					setTimeout(() => {
 						btnContinuar.classList.remove("oculto");
 						btnContinuar.onclick = () => mostrarPregunta(preguntas, indice + 1, aciertos, fallos);
 					}, 2000);
 				});
+				li.appendChild(botonOpcion);
 				opciones.appendChild(li);
 			});
 		}
 
-		document.getElementById("btn-finalizar").addEventListener("click", function () {
-			cambiarPantalla("pantalla-menu");
-		});
+		function mostrarError(mensaje, reintento) {
+			const contenedor = document.getElementById("mensaje-error");
+			const texto = document.getElementById("texto-error");
+			const boton = document.getElementById("btn-reintentar");
+			texto.textContent = mensaje;
+			contenedor.classList.remove("oculto");
+			if (reintento) {
+				ultimoIntento = reintento;
+				boton.classList.remove("oculto");
+			} else {
+				boton.classList.add("oculto");
+			}
+		}
+
+		function ocultarError() {
+			document.getElementById("mensaje-error").classList.add("oculto");
+			document.getElementById("texto-error").textContent = "";
+		}
+
+		function construirMensajeResultado(aciertos, totalPreguntas) {
+			const porcentaje = Math.round((aciertos / totalPreguntas) * 100);
+			if (porcentaje === 100) {
+				return "Pleno total. Te sabes este tema de memoria.";
+			}
+			if (porcentaje >= 80) {
+				return "Muy buen repaso. Dominas bastante bien este bloque.";
+			}
+			if (porcentaje >= 50) {
+				return "Buen avance. Ya tienes base, pero aún hay margen para consolidar.";
+			}
+			return "Buen intento. Repetir el cuestionario te ayudará a fijar mejor las ideas clave.";
+		}
+
+		function guardarConsentimientoCookies(valor) {
+			localStorage.setItem(COOKIE_CONSENT_KEY, valor);
+			document.getElementById("cookie-banner").classList.add("oculto");
+		}
+
+		function revisarConsentimientoCookies() {
+			const consentimiento = localStorage.getItem(COOKIE_CONSENT_KEY);
+			if (consentimiento === "accepted") {
+				inicializarAnalytics();
+				return;
+			}
+
+			if (consentimiento !== "rejected") {
+				document.getElementById("cookie-banner").classList.remove("oculto");
+			}
+		}
+
+		function inicializarAnalytics() {
+			if (window.analyticsLoaded) {
+				return;
+			}
+
+			window.dataLayer = window.dataLayer || [];
+			window.gtag = function () { window.dataLayer.push(arguments); };
+			const script = document.createElement("script");
+			script.async = true;
+			script.src = "https://www.googletagmanager.com/gtag/js?id=" + ANALYTICS_ID;
+			document.head.appendChild(script);
+			window.gtag("js", new Date());
+			window.gtag("config", ANALYTICS_ID);
+			window.analyticsLoaded = true;
+		}
+
+		revisarConsentimientoCookies();
 	</script>
 </body>
 

--- a/styles.css
+++ b/styles.css
@@ -1,109 +1,391 @@
-        body {
-        	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        	font-size: 16px;
-        	background-color: white;
-        	text-align: center;
-        	color: #333;
-        }
+body {
+	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+	font-size: 16px;
+	background:
+		radial-gradient(circle at top, #eef5ff 0%, #f8fbff 35%, #ffffff 70%);
+	text-align: center;
+	color: #333;
+	margin: 0;
+	padding: 0 0 140px;
+}
 
-        footer {
-        	text-align: center;
-        	font-size: 10px;
-        	padding: 10px;
-        	background-color: #f1f1f1;
-        	position: fixed;
-        	bottom: 0;
-        	width: 100%;
-        }
+footer {
+	text-align: center;
+	font-size: 10px;
+	padding: 10px;
+	background-color: rgba(241, 241, 241, 0.95);
+	position: fixed;
+	bottom: 0;
+	width: 100%;
+	backdrop-filter: blur(6px);
+}
 
-        h1 {
-        	font-size: 32px;
-        	background-color: #9aabbe;
-        	color: #007BFF;
-        }
+h1 {
+	font-size: 40px;
+	color: #0b63ce;
+	margin: 0;
+	padding: 0;
+}
 
-        h2 {
-        	font-size: 28px;
-        	color: #007BFF;
-        }
+h2 {
+	font-size: 30px;
+	color: #0b63ce;
+	margin-top: 0;
+}
 
-        .pantalla {
-        	display: none;
-        	padding: 20px;
-        }
+.pantalla {
+	display: none;
+	padding: 28px;
+	max-width: 900px;
+	margin: 0 auto;
+}
 
-        .pantalla.activa {
-        	display: block;
-        }
+.pantalla.activa {
+	display: block;
+}
 
-        .pantalla h1,
-        .pantalla h2 {
-        	font-size: 28px;
-        	color: #007BFF;
-        }
+.pantalla h1,
+.pantalla h2 {
+	font-size: 28px;
+	color: #007bff;
+}
 
-        button {
-        	font-size: 24px;
-        	padding: 10px 20px;
-        	margin-top: 20px;
-        	background-color: #28a745;
-        	color: white;
-        	border: none;
-        	border-radius: 5px;
-        	cursor: pointer;
-        }
+button {
+	font-size: 20px;
+	font-weight: 600;
+	padding: 12px 22px;
+	margin-top: 20px;
+	background-color: #1f8f46;
+	color: white;
+	border: none;
+	border-radius: 12px;
+	cursor: pointer;
+	box-shadow: 0 8px 18px rgba(31, 143, 70, 0.18);
+	transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
 
-        button:hover {
-        	background-color: #218838;
-        }
+button:hover {
+	background-color: #18733a;
+	transform: translateY(-1px);
+	box-shadow: 0 10px 22px rgba(31, 143, 70, 0.22);
+}
 
-        a {
-        	color: #007bff;
-        	text-decoration: none;
-        }
+button:focus-visible {
+	outline: 3px solid #003f88;
+	outline-offset: 3px;
+}
 
-        a:hover {
-        	text-decoration: underline;
-        }
+button:disabled {
+	cursor: not-allowed;
+	opacity: 0.85;
+}
 
-        ul {
-        	list-style: none;
-        	padding: 0;
-        }
+a {
+	color: #007bff;
+	text-decoration: none;
+}
 
-        li {
-        	font-size: 22px;
-        	padding: 10px;
-        	margin: 5px;
-        	background-color: #ffc107;
-        	border-radius: 5px;
-        	cursor: pointer;
-        }
+a:hover {
+	text-decoration: underline;
+}
 
-        li:hover {
-        	background-color: #e0a800;
-        }
+.site-header {
+	padding: 40px 20px 12px;
+}
 
-        .oculto {
-        	opacity: 0;
-        	visibility: hidden;
-        	transition: opacity 1.3s ease-in-out;
-        }
+.eyebrow {
+	margin: 0 0 10px;
+	font-size: 13px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: #4f6b8a;
+}
 
-        .imagen-pregunta {
-        	display: block;
-        	margin: 10px auto 20px auto;
-        	max-width: 40%;
-			border-radius: 12px;
-        	box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-        }
+.site-subtitle {
+	max-width: 680px;
+	margin: 10px auto 0;
+	font-size: 18px;
+	line-height: 1.5;
+	color: #4f5d73;
+}
 
-        .explicacion-visible {
-        	opacity: 1;
-        	visibility: visible;
-        	transition: opacity 1.3s ease-in-out;
-        	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        	font-size: 16px;
-        	color: white;
-        	background-color: #333;
-        }
+.app-shell {
+	padding: 0 16px;
+}
+
+.panel {
+	background-color: rgba(255, 255, 255, 0.92);
+	border: 1px solid #dce7f5;
+	border-radius: 24px;
+	box-shadow: 0 20px 50px rgba(30, 64, 175, 0.08);
+}
+
+.hero-copy {
+	max-width: 720px;
+	margin: 0 auto 18px;
+}
+
+.hero-copy p,
+.section-intro {
+	font-size: 18px;
+	line-height: 1.65;
+	color: #4f5d73;
+}
+
+.hero-highlights {
+	display: flex;
+	gap: 12px;
+	justify-content: center;
+	flex-wrap: wrap;
+	margin: 24px 0 8px;
+}
+
+.highlight-pill {
+	margin: 0;
+	padding: 10px 14px;
+	background-color: #eef5ff;
+	color: #24518b;
+	border: 1px solid #d6e5fb;
+	border-radius: 999px;
+	font-size: 14px;
+	font-weight: 600;
+}
+
+ul {
+	list-style: none;
+	padding: 0;
+}
+
+li {
+	margin: 10px 0;
+}
+
+.option-button {
+	width: min(100%, 720px);
+	font-size: 22px;
+	padding: 14px 18px;
+	margin-top: 0;
+	background-color: #f6c84c;
+	color: #222;
+	border: 2px solid transparent;
+	border-radius: 14px;
+	box-shadow: 0 8px 18px rgba(246, 200, 76, 0.2);
+}
+
+.option-button:hover {
+	background-color: #edbd3d;
+}
+
+.option-button.respuesta-correcta,
+.option-button.respuesta-correcta:hover {
+	background-color: #1f8f46;
+	color: white;
+	font-weight: bold;
+}
+
+.option-button.respuesta-correcta::after {
+	content: "  Correcta";
+}
+
+.option-button.respuesta-incorrecta,
+.option-button.respuesta-incorrecta:hover {
+	background-color: #b3261e;
+	color: white;
+	font-weight: bold;
+}
+
+.option-button.respuesta-incorrecta::after {
+	content: "  Incorrecta";
+}
+
+.topic-button {
+	background-color: #eef5ff;
+	color: #174a8b;
+	border-color: #d6e5fb;
+	box-shadow: none;
+}
+
+.topic-button:hover {
+	background-color: #e2efff;
+}
+
+.oculto {
+	display: none;
+}
+
+.imagen-pregunta {
+	display: block;
+	margin: 10px auto 20px auto;
+	max-width: min(90%, 380px);
+	border-radius: 12px;
+	box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.explicacion-visible {
+	display: block;
+	margin: 20px auto 0;
+	padding: 16px;
+	max-width: 720px;
+	border-radius: 12px;
+	font-size: 16px;
+	color: white;
+	background-color: #27364a;
+	line-height: 1.6;
+}
+
+.estado-respuesta {
+	min-height: 28px;
+	font-weight: 600;
+	color: #003f88;
+}
+
+.contador-pregunta {
+	font-size: 14px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: #666;
+}
+
+.mensaje-error {
+	max-width: 720px;
+	margin: 20px auto;
+	padding: 16px;
+	background-color: #fdecea;
+	color: #8a1c1c;
+	border: 1px solid #f5c2c0;
+	border-radius: 12px;
+}
+
+.results-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 16px;
+	margin: 28px auto 12px;
+	max-width: 720px;
+}
+
+.stat-card {
+	padding: 18px;
+	background-color: #f8fbff;
+	border: 1px solid #dce7f5;
+	border-radius: 18px;
+}
+
+.stat-label {
+	margin: 0 0 6px;
+	font-size: 14px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: #5f7087;
+}
+
+.stat-value {
+	margin: 0;
+	font-size: 36px;
+	font-weight: 700;
+	color: #123b73;
+}
+
+.results-actions {
+	display: flex;
+	justify-content: center;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.cookie-banner {
+	position: fixed;
+	left: 20px;
+	right: 20px;
+	bottom: 20px;
+	z-index: 1000;
+	max-width: 860px;
+	margin: 0 auto;
+	padding: 18px;
+	background-color: #111;
+	color: white;
+	border-radius: 14px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.cookie-banner a {
+	color: #f1d600;
+}
+
+.cookie-actions {
+	display: flex;
+	gap: 12px;
+	justify-content: center;
+	flex-wrap: wrap;
+}
+
+.secondary-button {
+	background-color: #555;
+	box-shadow: none;
+}
+
+.secondary-button:hover {
+	background-color: #444;
+	box-shadow: none;
+}
+
+@media (max-width: 768px) {
+	body {
+		padding-bottom: 156px;
+	}
+
+	h1 {
+		font-size: 32px;
+	}
+
+	h2 {
+		font-size: 24px;
+	}
+
+	.pantalla {
+		padding: 22px 18px;
+	}
+
+	.site-subtitle,
+	.hero-copy p,
+	.section-intro {
+		font-size: 16px;
+	}
+
+	button,
+	.option-button {
+		font-size: 18px;
+	}
+
+	.results-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.cookie-banner {
+		left: 12px;
+		right: 12px;
+		bottom: 12px;
+		padding: 16px;
+	}
+}
+
+@media (max-width: 480px) {
+	.site-header {
+		padding-top: 28px;
+	}
+
+	.eyebrow {
+		font-size: 12px;
+	}
+
+	.hero-highlights {
+		gap: 8px;
+	}
+
+	.highlight-pill {
+		width: 100%;
+	}
+}


### PR DESCRIPTION
## Qué cambia
(Cambios hechos con Codex app)
Esta PR refuerza la app en cuatro frentes:

- corrige problemas funcionales del quiz
- añade manejo de errores al cargar temas y cuestionarios
- mejora accesibilidad y cumplimiento básico de cookies
- da una segunda pasada de UX, copy y responsive

## Cambios principales

### Flujo del quiz
- se evita responder varias veces la misma pregunta
- se bloquean las opciones tras la primera respuesta
- se mantiene una breve pausa antes de avanzar
- se añade contador de progreso por pregunta

### Manejo de errores
- se controla el fallo al cargar `menu_temas.json`
- se controla el fallo al cargar cada cuestionario
- se muestra mensaje claro al usuario
- se añade botón de reintento

### Accesibilidad
- las respuestas pasan de `li` clicables a botones reales
- mejora la navegación por teclado
- el feedback ya no depende solo del color
- se añade `aria-live` para anunciar correcta/incorrecta

### Cookies y analítica
- Google Analytics deja de cargarse al entrar
- analytics solo se inicializa si el usuario acepta cookies
- el banner permite aceptar o rechazar
- la decisión se guarda en `localStorage`
- se actualiza la política de cookies para reflejar este comportamiento

### UX y responsive
- mejora la cabecera y la propuesta de valor
- el CTA principal pasa a `Empezar`
- mejora el copy de home y selección de tema
- la pantalla de resultados añade mensaje de desempeño
- se añaden tarjetas de métricas y opción de repetir cuestionario
- se refina el estilo visual y la adaptación móvil

## Archivos tocados

- `index.html`
- `styles.css`
- `docs/cookies.html`
- `docs/cambios-fix-quiz-hardening.md`

## Notas

La app sigue siendo estática y desplegable en GitHub Pages, sin añadir dependencias nuevas ni build tools.

## Validación

- `git diff --check` limpio
- revisión manual del diff completada

## Pendiente recomendable

- prueba visual rápida en móvil y desktop antes de merge
